### PR TITLE
Fix: macos double scrollbars

### DIFF
--- a/newtab.html
+++ b/newtab.html
@@ -9,7 +9,9 @@
   </head>
   <style>
     body {
-      margin: 0px;
+      margin: 0;
+      background-color: #222;
+      overflow: hidden;
     }
     #notes {
       box-sizing: border-box;


### PR DESCRIPTION
Hi. Using the web-ext across macOS/Win devices, and it works like a charm with sync. Thanks for sharing.

There is a weird issue on macOS where the body triggers another scrollbar. This only happen with a plugged-in mouse.
The `overflow: hidden` fixes this and has no bad side effects.

![Screenshot at Jun 27 22-57-28](https://user-images.githubusercontent.com/19303435/176037993-ab35a9e7-57bb-4e0a-8953-74c5f127eb4f.png)


The additional color on body is for over scrolling on macOS (touchpad).  